### PR TITLE
Compound word class names properly underscored

### DIFF
--- a/lib/phlex/translation.rb
+++ b/lib/phlex/translation.rb
@@ -10,13 +10,11 @@ module Phlex
 			attr_writer :translation_path
 
 			def translation_path
-        @translation_path ||= name
-                                &.split("::")
-                                &.join(".")
-                                &.gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-                                &.gsub(/([a-z\d])([A-Z])/,'\1_\2')
-                                &.tr("-", "_")
-                                &.downcase.to_s
+        @translation_path ||= name&.dup.tap do |n|
+          n.gsub!("::", ".")
+          n.gsub!(/([a-z])([A-Z])/, '\1_\2')
+          n.downcase!
+        end
       end
 
 		end

--- a/lib/phlex/translation.rb
+++ b/lib/phlex/translation.rb
@@ -10,8 +10,15 @@ module Phlex
 			attr_writer :translation_path
 
 			def translation_path
-				@translation_path ||= name&.split("::")&.join(".")&.downcase.to_s
-			end
+        @translation_path ||= name
+                                &.split("::")
+                                &.join(".")
+                                &.gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+                                &.gsub(/([a-z\d])([A-Z])/,'\1_\2')
+                                &.tr("-", "_")
+                                &.downcase.to_s
+      end
+
 		end
 
 		def translate(key, **options)

--- a/test/phlex/translation.rb
+++ b/test/phlex/translation.rb
@@ -49,7 +49,13 @@ describe Phlex::Translation do
 			it "returns I18n scope using class anme" do
 				expect(Views::Articles::Form.translation_path).to be == "views.articles.form"
 			end
-		end
+    end
+
+    with "a class name with a multiple word class or module name" do
+      it "converts the names to snake case" do
+        expect(Views::Articles::OtherForm.translation_path).to be == "views.articles.other_form"
+      end
+    end
 
 		with "invalid class_name" do
 			it "returns empty string" do


### PR DESCRIPTION
Converts "ThisClass" to "this_class" instead of "thisclass".

Tests are broken, prolly as a result of the repo splitting, but I wrote a test that I think might work? But it looks like `Views::Articles::Form` is defined in one of those missing support files, so it might not work.